### PR TITLE
Add GitLab community MCP server integration

### DIFF
--- a/registry/gitlab/spec.yaml
+++ b/registry/gitlab/spec.yaml
@@ -1,0 +1,170 @@
+name: gitlab
+description:
+  Provides integration with a GitLab instance to manage projects, issues, merge
+  requests, and more.
+tier: Community
+status: Active
+transport: streamable-http
+target_port: 3002
+image: iwakitakuma/gitlab-mcp:2.0.3
+repository_url: https://github.com/zereight/gitlab-mcp
+tools:
+  - merge_merge_request
+  - create_or_update_file
+  - search_repositories
+  - create_repository
+  - get_file_contents
+  - push_files
+  - create_issue
+  - create_merge_request
+  - fork_repository
+  - create_branch
+  - get_merge_request
+  - get_merge_request_diffs
+  - list_merge_request_diffs
+  - get_branch_diffs
+  - update_merge_request
+  - create_note
+  - create_merge_request_thread
+  - mr_discussions
+  - update_merge_request_note
+  - create_merge_request_note
+  - get_draft_note
+  - list_draft_notes
+  - create_draft_note
+  - update_draft_note
+  - delete_draft_note
+  - publish_draft_note
+  - bulk_publish_draft_notes
+  - update_issue_note
+  - create_issue_note
+  - list_issues
+  - my_issues
+  - get_issue
+  - update_issue
+  - delete_issue
+  - list_issue_links
+  - list_issue_discussions
+  - get_issue_link
+  - create_issue_link
+  - delete_issue_link
+  - list_namespaces
+  - get_namespace
+  - verify_namespace
+  - get_project
+  - list_projects
+  - list_project_members
+  - list_labels
+  - get_label
+  - create_label
+  - update_label
+  - delete_label
+  - list_group_projects
+  - list_wiki_pages
+  - get_wiki_page
+  - create_wiki_page
+  - update_wiki_page
+  - delete_wiki_page
+  - get_repository_tree
+  - list_pipelines
+  - get_pipeline
+  - list_pipeline_jobs
+  - list_pipeline_trigger_jobs
+  - get_pipeline_job
+  - get_pipeline_job_output
+  - create_pipeline
+  - retry_pipeline
+  - cancel_pipeline
+  - list_merge_requests
+  - list_milestones
+  - get_milestone
+  - create_milestone
+  - edit_milestone
+  - delete_milestone
+  - get_milestone_issue
+  - get_milestone_merge_requests
+  - promote_milestone
+  - get_milestone_burndown_events
+  - get_users
+  - list_commits
+  - get_commit
+  - get_commit_diff
+  - list_group_iterations
+  - upload_markdown
+  - download_attachment
+env_vars:
+  - name: GITLAB_PERSONAL_ACCESS_TOKEN
+    description: Your GitLab personal access token.
+    required: true
+    secret: true
+  - name: GITLAB_API_URL
+    description: Your GitLab API URL.
+    required: false
+    default: https://gitlab.com/api/v4
+  - name: GITLAB_PROJECT_ID
+    description:
+      Default project ID. If set, overwrite this value when making an API
+      request.
+    required: false
+  - name: GITLAB_ALLOWED_PROJECT_IDS
+    description:
+      Optional comma-separated list of allowed project IDs. When set with a
+      single value, acts as a default project (like the old "lock" mode). When
+      set with multiple values, restricts access to only those projects.
+    required: false
+  - name: GITLAB_READ_ONLY_MODE
+    description:
+      When set to 'true', restricts the server to only expose read-only
+      operations. Useful for enhanced security or when write access is not
+      needed. Also useful for using with Cursor and its 40 tool limit.
+    required: false
+  - name: USE_GITLAB_WIKI
+    description:
+      When set to 'true', enables the wiki-related tools. By default, wiki
+      features are disabled.
+    required: false
+  - name: USE_MILESTONE
+    description:
+      When set to 'true', enables the milestone-related tools. By default,
+      milestone features are disabled.
+    required: false
+  - name: USE_PIPELINE
+    description:
+      When set to 'true', enables the pipeline-related tools. By default,
+      pipeline features are disabled.
+    required: false
+  - name: GITLAB_AUTH_COOKIE_PATH
+    description:
+      Path to an authentication cookie file for GitLab instances that require
+      cookie-based authentication. When provided, the cookie will be included in
+      all GitLab API requests.
+    required: false
+  - name: SSE
+    description: When set to 'true', enables the Server-Sent Events transport.
+    required: false
+  - name: STREAMABLE_HTTP
+    description:
+      When set to 'true', enables the Streamable HTTP transport. If both SSE and
+      STREAMABLE_HTTP are set to 'true', the server will prioritize Streamable
+      HTTP over SSE transport.
+    required: false
+    default: true
+permissions:
+  network:
+    outbound:
+      allow_host:
+        - .gitlab.com
+        - .gitlab-static.net
+        - .gitlab.io
+        - .gitlab.net
+      allow_port:
+        - 443
+tags:
+  - gitlab
+  - version-control
+  - repository
+  - issues
+  - merge-requests
+  - wiki
+  - milestones
+  - pipelines

--- a/registry/gitlab/spec.yaml
+++ b/registry/gitlab/spec.yaml
@@ -1,7 +1,5 @@
 name: gitlab
-description:
-  Provides integration with a GitLab instance to manage projects, issues, merge
-  requests, and more.
+description: Provides integration with a GitLab instance to manage projects, issues, merge requests, and more.
 tier: Community
 status: Active
 transport: streamable-http
@@ -102,51 +100,31 @@ env_vars:
     required: false
     default: https://gitlab.com/api/v4
   - name: GITLAB_PROJECT_ID
-    description:
-      Default project ID. If set, overwrite this value when making an API
-      request.
+    description: Default project ID. If set, overwrite this value when making an API request.
     required: false
   - name: GITLAB_ALLOWED_PROJECT_IDS
-    description:
-      Optional comma-separated list of allowed project IDs. When set with a
-      single value, acts as a default project (like the old "lock" mode). When
-      set with multiple values, restricts access to only those projects.
+    description: Optional comma-separated list of allowed project IDs. When set with a single value, acts as a default project (like the old "lock" mode). When set with multiple values, restricts access to only those projects.
     required: false
   - name: GITLAB_READ_ONLY_MODE
-    description:
-      When set to 'true', restricts the server to only expose read-only
-      operations. Useful for enhanced security or when write access is not
-      needed. Also useful for using with Cursor and its 40 tool limit.
+    description: When set to 'true', restricts the server to only expose read-only operations. Useful for enhanced security or when write access is not needed. Also useful for using with Cursor and its 40 tool limit.
     required: false
   - name: USE_GITLAB_WIKI
-    description:
-      When set to 'true', enables the wiki-related tools. By default, wiki
-      features are disabled.
+    description: When set to 'true', enables the wiki-related tools. By default, wiki features are disabled.
     required: false
   - name: USE_MILESTONE
-    description:
-      When set to 'true', enables the milestone-related tools. By default,
-      milestone features are disabled.
+    description: When set to 'true', enables the milestone-related tools. By default, milestone features are disabled.
     required: false
   - name: USE_PIPELINE
-    description:
-      When set to 'true', enables the pipeline-related tools. By default,
-      pipeline features are disabled.
+    description: When set to 'true', enables the pipeline-related tools. By default, pipeline features are disabled.
     required: false
   - name: GITLAB_AUTH_COOKIE_PATH
-    description:
-      Path to an authentication cookie file for GitLab instances that require
-      cookie-based authentication. When provided, the cookie will be included in
-      all GitLab API requests.
+    description: Path to an authentication cookie file for GitLab instances that require cookie-based authentication. When provided, the cookie will be included in all GitLab API requests.
     required: false
   - name: SSE
     description: When set to 'true', enables the Server-Sent Events transport.
     required: false
   - name: STREAMABLE_HTTP
-    description:
-      When set to 'true', enables the Streamable HTTP transport. If both SSE and
-      STREAMABLE_HTTP are set to 'true', the server will prioritize Streamable
-      HTTP over SSE transport.
+    description: When set to 'true', enables the Streamable HTTP transport. If both SSE and STREAMABLE_HTTP are set to 'true', the server will prioritize Streamable HTTP over SSE transport.
     required: false
     default: true
 permissions:
@@ -168,3 +146,7 @@ tags:
   - wiki
   - milestones
   - pipelines
+metadata:
+  stars: 509
+  pulls: 9715
+  last_updated: 2025-08-26T17:28:57Z


### PR DESCRIPTION
Adds the zereight/gitlab-mcp server for GitLab.

Tested with my own GitLab account, including testing with network isolation enabled.

Note, GitLab also has an official remote MCP server but it's in preview; should we determine a naming scheme now for local/remote or community/official MCPs? I've just called this one `gitlab`.

Closes stacklok/toolhive#827

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>