### PR TITLE
fix: reduce GitLab env var description lengths

### DIFF
--- a/registry/gitlab/spec.yaml
+++ b/registry/gitlab/spec.yaml
@@ -105,10 +105,10 @@ env_vars:
     description: Default project ID. If set, overwrite this value when making an API request.
     required: false
   - name: GITLAB_ALLOWED_PROJECT_IDS
-    description: Optional comma-separated list of allowed project IDs. When set with a single value, acts as a default project (like the old "lock" mode). When set with multiple values, restricts access to only those projects.
+    description: Optional comma-separated list of allowed project IDs. When set with a single value, acts as a default project.
     required: false
   - name: GITLAB_READ_ONLY_MODE
-    description: When set to 'true', restricts the server to only expose read-only operations. Useful for enhanced security or when write access is not needed. Also useful for using with Cursor and its 40 tool limit.
+    description: When set to 'true', restricts the server to only expose read-only operations.
     required: false
   - name: USE_GITLAB_WIKI
     description: When set to 'true', enables the wiki-related tools. By default, wiki features are disabled.
@@ -120,13 +120,13 @@ env_vars:
     description: When set to 'true', enables the pipeline-related tools. By default, pipeline features are disabled.
     required: false
   - name: GITLAB_AUTH_COOKIE_PATH
-    description: Path to an authentication cookie file for GitLab instances that require cookie-based authentication. When provided, the cookie will be included in all GitLab API requests.
+    description: Path to an authentication cookie file for GitLab instances that require cookie-based authentication.
     required: false
   - name: SSE
     description: When set to 'true', enables the Server-Sent Events transport.
     required: false
   - name: STREAMABLE_HTTP
-    description: When set to 'true', enables the Streamable HTTP transport. If both SSE and STREAMABLE_HTTP are set to 'true', the server will prioritize Streamable HTTP over SSE transport.
+    description: When set to 'true', enables the Streamable HTTP transport. If both SSE and STREAMABLE_HTTP are set to 'true', Streamable HTTP is used.
     required: false
     default: true
 permissions:


### PR DESCRIPTION
Caused a validation error in CI

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>