### PR TITLE
Removing non-valid status from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,6 @@ If you're not sure, use `stdio` for containers and `sse` for remote servers.
 ### What is "status"?
 
 - `Active` - Fully functional and maintained
-- `Beta` - Still in development but usable
-- `Alpha` - Early development, may have issues
 - `Deprecated` - No longer maintained, will be removed
 
 ### Do I need a Docker image?


### PR DESCRIPTION
Closes: #140 

The README mentioned status that were actually not valid. Removing them to only leave the valid ones