### PR TITLE
fix: add `--allowed-hosts` arg to Playwright MCP spec

### DIFF
--- a/registry/playwright/spec.yaml
+++ b/registry/playwright/spec.yaml
@@ -1,6 +1,6 @@
 # playwright MCP Server Registry Entry
 # Auto-imported from ToolHive registry.json
-# 
+#
 # Original source: https://github.com/stacklok/toolhive
 # Import timestamp: 2025-08-14T07:27:00Z
 # ---
@@ -40,7 +40,7 @@ tools:
 metadata:
   stars: 20378
   pulls: 23622
-  last_updated: "2025-09-26T02:29:10Z"
+  last_updated: '2025-09-26T02:29:10Z'
 repository_url: https://github.com/microsoft/playwright-mcp
 tags:
   - playwright
@@ -57,4 +57,6 @@ permissions:
         - 443
 args:
   - --port
-  - "8931"
+  - '8931'
+  - --allowed-hosts
+  - '*'


### PR DESCRIPTION
The Playwright MCP v0.40.0 introduced a host header check, so it's been throwing errors to clients:

```
Connection state: Error 403 status sending message to http://localhost:57501/mcp: Access is only allowed at localhost:8931
```

Adding the `--allowed-hosts "*"` argument disables this, since we can't know the host header ahead of time (it'll be a random port, or some K8s ingress URL).

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>