### PR TITLE
Fix issue where the update flow was not committing the changes

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -184,16 +184,13 @@ jobs:
             fi
           fi
 
-      - name: Stage changes for later commit
+      - name: Prepare changes for commit
         if: (steps.update.outputs.changed == 'true' || steps.update.outputs.warning-added == 'true') && github.event_name == 'pull_request'
         run: |
-          # Just stage the files, don't commit yet
-          git add "${{ matrix.spec }}"
-          
-          # Create a summary file for the commit job to use
+          # Create artifact directory with both metadata and the actual changed file
           SERVER_NAME="${{ steps.server-info.outputs.server-name }}"
           mkdir -p /tmp/commit-info
-          
+
           if [ "${{ steps.update.outputs.changed }}" = "true" ]; then
             echo "update" > "/tmp/commit-info/${SERVER_NAME}.type"
             echo "$SERVER_NAME" > "/tmp/commit-info/${SERVER_NAME}.name"
@@ -203,7 +200,10 @@ jobs:
             echo "$SERVER_NAME" > "/tmp/commit-info/${SERVER_NAME}.name"
             echo "${{ matrix.spec }}" > "/tmp/commit-info/${SERVER_NAME}.spec"
           fi
-      
+
+          # Copy the modified spec file to the artifact directory
+          cp "${{ matrix.spec }}" "/tmp/commit-info/${SERVER_NAME}.spec.yaml"
+
       - name: Upload commit info
         if: (steps.update.outputs.changed == 'true' || steps.update.outputs.warning-added == 'true') && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
@@ -281,44 +281,49 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          
+
           # Pull any remote changes first to avoid conflicts
           git pull origin ${{ github.head_ref || github.ref_name }} --rebase
-          
+
           # Collect all the server names that were updated
           UPDATED_SERVERS=""
           WARNING_SERVERS=""
-          
+
           for file in /tmp/artifacts/*.type; do
             if [ -f "$file" ]; then
               SERVER_NAME=$(basename "$file" .type)
               TYPE=$(cat "$file")
-              
+
               if [ "$TYPE" = "update" ]; then
                 UPDATED_SERVERS="$UPDATED_SERVERS $SERVER_NAME"
               else
                 WARNING_SERVERS="$WARNING_SERVERS $SERVER_NAME"
               fi
-              
-              # Stage the corresponding spec file
+
+              # Restore the modified spec file from the artifact
               SPEC_FILE=$(cat "/tmp/artifacts/${SERVER_NAME}.spec")
-              git add "$SPEC_FILE"
+              if [ -f "/tmp/artifacts/${SERVER_NAME}.spec.yaml" ]; then
+                cp "/tmp/artifacts/${SERVER_NAME}.spec.yaml" "$SPEC_FILE"
+                git add "$SPEC_FILE"
+              else
+                echo "Warning: Modified spec file not found in artifacts for $SERVER_NAME"
+              fi
             fi
           done
-          
+
           # Create commit message
           COMMIT_MSG="chore: update tool lists for MCP servers"
-          
+
           if [ -n "$UPDATED_SERVERS" ]; then
             COMMIT_MSG="$COMMIT_MSG\n\nUpdated servers:$(echo $UPDATED_SERVERS | sed 's/ /\\n- /g' | sed 's/^/\\n- /')"
           fi
-          
+
           if [ -n "$WARNING_SERVERS" ]; then
             COMMIT_MSG="$COMMIT_MSG\n\nWarning added for servers:$(echo $WARNING_SERVERS | sed 's/ /\\n- /g' | sed 's/^/\\n- /')"
           fi
-          
+
           COMMIT_MSG="$COMMIT_MSG\n\nAutomatically updated using 'thv mcp list' command.\n\nCo-authored-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
-          
+
           # Check if there are actually any changes to commit
           if ! git diff --cached --quiet; then
             git commit -m "$COMMIT_MSG"


### PR DESCRIPTION
The automatic tool list update workflow was successfully running but failing to commit changes to PRs.

**Problem:** 
- The commit-all-changes job was checking out fresh code and only receiving metadata artifacts (.type, .name, .spec files) from the update-tools job. Without the actual modified spec files, git add had nothing to stage, resulting in "No changes to commit" messages.

**Solution**
- Modified spec files are now included in the artifacts uploaded by update-tools
- The commit-all-changes job restores these files before staging and committing
- This preserves file changes across GitHub Actions job boundaries


**Detailed description:**
```
  The Issue

  Background: How GitHub Actions Jobs Work

  GitHub Actions workflows can have multiple jobs. Each job runs in a completely separate virtual machine (runner). This means:

  - Each job starts with a fresh checkout of your repository
  - Files created or modified in one job don't automatically exist in another job
  - The only way to share data between jobs is through artifacts (uploaded files) or outputs (small text values)

  What Was Happening (The Bug)

  Let's trace through the workflow for PR #202:

  Step 1: update-tools job runs (lines 112-246)

  - Checkout code
  - Build the update-tools binary
  - Run: ./update-tools registry/semgrep/spec.yaml
    → This MODIFIES registry/semgrep/spec.yaml (adds/updates tool list)
  - Check if file changed: git diff shows changes ✓
  - Stage changes for later commit:
      git add registry/semgrep/spec.yaml  # File is staged in THIS runner
  - Create metadata files:
      echo "update" > /tmp/commit-info/semgrep.type
      echo "semgrep" > /tmp/commit-info/semgrep.name
      echo "registry/semgrep/spec.yaml" > /tmp/commit-info/semgrep.spec
  - Upload artifacts (only metadata, NOT the modified spec.yaml)
  - Job ends, runner is destroyed

  At this point, the modified registry/semgrep/spec.yaml file is gone because the runner was destroyed.

  Step 2: commit-all-changes job runs (lines 248-329)

  - Checkout code (FRESH, unmodified copy)
  - Download artifacts:
      /tmp/artifacts/semgrep.type     → contains "update"
      /tmp/artifacts/semgrep.name     → contains "semgrep"
      /tmp/artifacts/semgrep.spec     → contains "registry/semgrep/spec.yaml"
  - Try to commit:
      SPEC_FILE="registry/semgrep/spec.yaml"
      git add "$SPEC_FILE"  # Tries to stage registry/semgrep/spec.yaml
      git diff --cached --quiet  # Checks if anything is staged
      → Returns TRUE (nothing staged) because the file is identical to repo
      → "No changes to commit"

  The problem: The workflow was trying to git add a file that hadn't been modified in this job, so there was nothing to commit.

  Why This Wasn't Caught Initially

  The workflow probably worked at some point because:
  1. It might have been a single job originally (no separation between update and commit)
  2. Or there was a different mechanism that got lost during refactoring
  3. The commit "succeeded" (no errors), it just didn't create a commit

  Looking at the git history, commit 1f031ef mentions "Try to resolve the race condition" - suggesting this separation was added to fix a different issue (race conditions when multiple servers update simultaneously), but it introduced this artifact problem.

  The Solution

  What We Changed

  In the update-tools job (line 205):
  # OLD: Only uploaded metadata
  - Create metadata files (type, name, spec path)
  - Upload artifacts

  # NEW: Also upload the actual modified file
  - Create metadata files (type, name, spec path)
  - Copy the modified spec file to the artifact directory:
      cp registry/semgrep/spec.yaml /tmp/commit-info/semgrep.spec.yaml
  - Upload artifacts (now includes the actual modified file)

  In the commit-all-changes job (lines 303-310):
  # OLD: Just tried to stage the file (which hadn't changed)
  SPEC_FILE=$(cat "/tmp/artifacts/semgrep.spec")
  git add "$SPEC_FILE"

  # NEW: Restore the modified file first, THEN stage it
  SPEC_FILE=$(cat "/tmp/artifacts/semgrep.spec")
  if [ -f "/tmp/artifacts/semgrep.spec.yaml" ]; then
    cp "/tmp/artifacts/semgrep.spec.yaml" "$SPEC_FILE"  # Restore modified version
    git add "$SPEC_FILE"  # Now there are changes to stage!
  fi

  How It Works Now

  Step 1: update-tools job

  1. Modifies registry/semgrep/spec.yaml
  2. Uploads BOTH:
     - Metadata: semgrep.type, semgrep.name, semgrep.spec
     - Modified file: semgrep.spec.yaml (the actual changed content)

  Step 2: commit-all-changes job

  1. Checks out fresh code (unmodified)
  2. Downloads artifacts (metadata + modified files)
  3. Restores: cp semgrep.spec.yaml → registry/semgrep/spec.yaml
  4. Now registry/semgrep/spec.yaml has the changes!
  5. git add registry/semgrep/spec.yaml (stages the changes)
  6. git commit (creates commit with the changes)
  7. git push (pushes to PR)

  Why This Approach?

  You might ask: why not just commit in the update-tools job?

  The workflow uses a matrix strategy to process multiple servers in parallel:
  strategy:
    matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}

  If multiple spec files change in one PR, multiple update-tools jobs run simultaneously. If each tried to commit independently, they'd create:
  - Multiple commits (one per server)
  - Race conditions (jobs pushing at the same time)

  By having a single commit-all-changes job that runs after all updates complete, we get:
  - One consolidated commit for all changes
  - No race conditions
  - Better commit message listing all updated servers

  The tradeoff is we need to pass the modified files between jobs via artifacts, which is what this fix implements.
```