### PR TITLE
feat: switch notion local to dockyard image, update envs

### DIFF
--- a/registry/notion/spec.yaml
+++ b/registry/notion/spec.yaml
@@ -31,7 +31,7 @@ repository_url: https://github.com/makenotion/notion-mcp-server
 tags:
   - notion
   - notes
-image: mcp/notion:latest
+image: ghcr.io/stacklok/dockyard/npx/notion:1.9.0
 args: []
 permissions:
   network:
@@ -41,7 +41,13 @@ permissions:
       allow_port:
         - 443
 env_vars:
-  - name: OPENAPI_MCP_HEADERS
-    description: 'HTTP headers for Notion API requests in JSON format. Example: {"Authorization":"Bearer ntn_****","Notion-Version":"2022-06-28"}'
+  - name: NOTION_TOKEN
+    description: Notion integration token (ntn_****).
     required: true
+    secret: true
+  - name: OPENAPI_MCP_HEADERS
+    description:
+      'HTTP headers for Notion API requests in JSON format (advanced use cases).
+      Example: {"Authorization":"Bearer ntn_****","Notion-Version":"2022-06-28"}'
+    required: false
     secret: true


### PR DESCRIPTION
Updating the local Notion MCP to use the Dockyard image with version pinning.

Notion added a new simpler NOTION_TOKEN instead of requiring a full header JSON. Marking it required since it's the preferred approach.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>