### PR TITLE
feat: update context7 with new env var and network permissions

### DIFF
--- a/registry/context7/spec.yaml
+++ b/registry/context7/spec.yaml
@@ -6,7 +6,7 @@
 # ---
 name: context7
 description: Context7 MCP pulls version-specific docs and code examples directly into your prompt
-tier: Community
+tier: Official
 status: Active
 transport: stdio
 tools:

--- a/registry/context7/spec.yaml
+++ b/registry/context7/spec.yaml
@@ -13,20 +13,27 @@ tools:
   - resolve-library-id
   - get-library-docs
 metadata:
-  stars: 31260
+  stars: 32836
   pulls: 313
-  last_updated: "2025-09-24T02:28:46Z"
+  last_updated: "2025-10-07T20:17:57Z"
 repository_url: https://github.com/upstash/context7
 tags:
   - documentation
   - modelcontextprotocol
-image: ghcr.io/stacklok/dockyard/npx/context7:1.0.20
+image: ghcr.io/stacklok/dockyard/npx/context7:1.0.21
 permissions:
   network:
     outbound:
-      insecure_allow_all: true
+      insecure_allow_all: false
+      allow_host:
+        - context7.com
       allow_port:
         - 443
+env_vars:
+  - name: CONTEXT7_API_KEY
+    description: API key for higher rate limits
+    required: false
+    secret: true
 provenance:
   cert_issuer: https://token.actions.githubusercontent.com
   repository_uri: https://github.com/stacklok/dockyard

--- a/registry/context7/spec.yaml
+++ b/registry/context7/spec.yaml
@@ -19,7 +19,7 @@ metadata:
 repository_url: https://github.com/upstash/context7
 tags:
   - documentation
-  - modelcontextprotocol
+  - code-examples
 image: ghcr.io/stacklok/dockyard/npx/context7:1.0.21
 permissions:
   network:


### PR DESCRIPTION
v1.0.21 of context7 added env var support for the optional API key, which is better for ToolHive users than the old cmd arg.

Also tighened the default network isolation permissions since only context7.com is needed.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>